### PR TITLE
Add healthcheck script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV PATH /usr/pgsql-9.5/bin:$PATH
 
 COPY postgresql.conf /conf/postgresql.conf
 COPY docker-entrypoint.sh /
+COPY healthcheck.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 5432

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ COPY postgresql.conf /conf/postgresql.con
 
 The entrypoint will automatically copy this to the postgres configuration directory after the db has been initialized
 
+### Useful File Locations
+
+* `/docker-entrypoint-initdb.d/*.sql[.gz]` - Any SQL file in that
+  location will be loaded into the database on container init.
+* `/healthcheck.sh` - You can execute this file to check the health of
+  the postgres installation. It performs `SELECT 1+1` on the database.
+
 ## Contributing
 
 Feel free to submit pull requests and issues. If it's a particularly large PR, you may wish to

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+PGPASSWORD=${POSTGRES_PASSWORD} \
+  echo "SELECT 1+1;" \
+  | psql -U "${POSTGRES_USER}" -w \
+  > /dev/null
+
+exit $?


### PR DESCRIPTION
Adds a healthcheck script that will tell you whether postgres is
running.

Ported from @PurpleBooth's [commit on the docker-mysql repo](https://github.com/UKHomeOffice/docker-mysql/commit/31053026984fbf342b978c763641a4720537a2f4).
